### PR TITLE
spring-xom-unmarshaller: Update auf Spring Boot 4.1.X und Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
+      - spring-boot-4-migration
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Spring XML Unmarshalling with [XOM](http://www.xom.nu/)
 <dependency>
   <groupId>com.itelg.spring</groupId>
   <artifactId>spring-xom-unmarshaller</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-scm-provider-gitexe.version>1.11.3</maven-scm-provider-gitexe.version>
+    <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
     <commons-io.version>2.22.0</commons-io.version>
     <!-- Testing -->
     <jacoco.version>0.8.15</jacoco.version>
+    <!-- Explicit so Sonar reads the combined UT+IT jacoco report instead of guessing via scanner-default path conventions. -->
+    <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencyManagement>
@@ -127,6 +129,7 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
+          <proc>full</proc>
         </configuration>
       </plugin>
       <plugin>
@@ -185,6 +188,7 @@
           <argLine>-Duser.timezone=Europe/Berlin</argLine>
           <systemPropertyVariables>
             <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+            <jacoco-agent.append>true</jacoco-agent.append>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -194,6 +198,10 @@
         <version>${maven-failsafe-plugin.version}</version>
         <configuration>
           <reportsDirectory>target/surefire-reports</reportsDirectory>
+          <systemPropertyVariables>
+            <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+            <jacoco-agent.append>true</jacoco-agent.append>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>
@@ -232,54 +240,28 @@
               <goal>restore-instrumented-classes</goal>
             </goals>
           </execution>
+          <!--
+            default-restore-instrumented-classes above runs at its default phase (prepare-package) to keep the
+            packaged jar free of instrumented bytecode. But that means classes are back to non-instrumented by the
+            time integration-test runs (pre-integration-test/integration-test come after prepare-package/package in
+            the lifecycle) - so without re-instrumenting here, Failsafe would silently record zero IT coverage.
+          -->
           <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
+            <id>pre-integration-test-instrument</id>
+            <phase>pre-integration-test</phase>
             <goals>
-              <goal>report</goal>
+              <goal>instrument</goal>
             </goals>
-            <configuration>
-              <dataFile>target/jacoco-ut.exec</dataFile>
-              <outputDirectory>target/jacoco-ut</outputDirectory>
-            </configuration>
           </execution>
           <execution>
-            <id>integration-test-report</id>
+            <id>post-integration-test-restore</id>
             <phase>post-integration-test</phase>
             <goals>
-              <goal>report</goal>
-            </goals>
-            <configuration>
-              <dataFile>target/jacoco-it.exec</dataFile>
-              <outputDirectory>target/jacoco-it</outputDirectory>
-            </configuration>
-          </execution>
-          <execution>
-            <id>agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
+              <goal>restore-instrumented-classes</goal>
             </goals>
           </execution>
           <execution>
-            <id>merge-results</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>merge</goal>
-            </goals>
-            <configuration>
-              <fileSets>
-                <fileSet>
-                  <directory>target</directory>
-                  <includes>
-                    <include>*.exec</include>
-                  </includes>
-                </fileSet>
-              </fileSets>
-              <destFile>target/jacoco.exec</destFile>
-            </configuration>
-          </execution>
-          <execution>
-            <id>post-merge-report</id>
+            <id>report</id>
             <phase>verify</phase>
             <goals>
               <goal>report</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.itelg.spring</groupId>
   <artifactId>spring-xom-unmarshaller</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 
   <name>spring-xom-unmarshaller</name>
   <description>Spring XML Unmarshalling with XOM</description>
@@ -32,7 +32,7 @@
     <!-- Build -->
     <maven.build.timestamp.format>dd.MM.yyyy HH:mm</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -45,9 +45,9 @@
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Spring -->
-    <spring-boot.version>3.5.16</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <!-- Other -->
-    <xpath-helper.version>1.0.0</xpath-helper.version>
+    <xpath-helper.version>2.0.0-RC1</xpath-helper.version>
     <commons-io.version>2.22.0</commons-io.version>
     <!-- Testing -->
     <jacoco.version>0.8.15</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
     <!-- Other -->
     <xpath-helper.version>2.0.0-RC1</xpath-helper.version>
     <commons-io.version>2.22.0</commons-io.version>
+    <!-- lombok must be pinned explicitly for the annotation-processor path; kept in sync with the Spring Boot BOM -->
+    <lombok.version>1.18.46</lombok.version>
     <!-- Testing -->
     <jacoco.version>0.8.15</jacoco.version>
     <!-- Explicit so Sonar reads the combined UT+IT jacoco report instead of guessing via scanner-default path conventions. -->
@@ -85,6 +87,11 @@
     </dependency>
 
     <!-- Other -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.itelg</groupId>
       <artifactId>xpath-helper</artifactId>

--- a/src/main/java/com/itelg/spring/xom/unmarshaller/parser/ParserHolder.java
+++ b/src/main/java/com/itelg/spring/xom/unmarshaller/parser/ParserHolder.java
@@ -5,34 +5,30 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class ParserHolder
 {
+    @Getter
+    @Setter
     private Parser<?> parser;
+
+    @Getter
+    @Setter
     private Class<?> returnType;
+
     private Set<String> supportedRootTags = new HashSet<>();
+
     private String xpathExpression;
+
+    @Getter
+    @Setter
     private String xpathExpressionValue;
 
-    public Parser<?> getParser()
-    {
-        return parser;
-    }
-
-    public void setParser(Parser<?> parser)
-    {
-        this.parser = parser;
-    }
-
-    public Class<?> getReturnType()
-    {
-        return returnType;
-    }
-
-    public void setReturnType(Class<?> returnType)
-    {
-        this.returnType = returnType;
-    }
-
+    /**
+     * Hand-written because it hands out a copy: the field is a {@link Set}, the accessor a {@link List}.
+     */
     public List<String> getSupportedRootTags()
     {
         return new ArrayList<>(supportedRootTags);
@@ -43,6 +39,9 @@ public class ParserHolder
         supportedRootTags.add(rootTag);
     }
 
+    /**
+     * Hand-written because of the capital P: a generated accessor would be named getXpathExpression.
+     */
     public String getXPathExpression()
     {
         return xpathExpression;
@@ -51,15 +50,5 @@ public class ParserHolder
     public void setXPathExpression(String xpathExpression)
     {
         this.xpathExpression = xpathExpression;
-    }
-
-    public String getXpathExpressionValue()
-    {
-        return xpathExpressionValue;
-    }
-
-    public void setXpathExpressionValue(String xpathExpressionValue)
-    {
-        this.xpathExpressionValue = xpathExpressionValue;
     }
 }

--- a/src/main/java/com/itelg/spring/xom/unmarshaller/utils/XomUnmarshallingAmqpMessageConverter.java
+++ b/src/main/java/com/itelg/spring/xom/unmarshaller/utils/XomUnmarshallingAmqpMessageConverter.java
@@ -10,7 +10,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
 


### PR DESCRIPTION
Hebt `spring-xom-unmarshaller` auf Spring Boot 4.1.0 und Java 25. Zielversion **3.0.0-RC1**.

- `ParserHolder` auf Lombok umgestellt. `getSupportedRootTags()` bleibt handgeschrieben (gibt eine Kopie zurueck), `getXPathExpression()` wegen des grossen P im Namen.

### Merge-Reihenfolge

Die CI dieses PRs bleibt so lange rot, bis die folgenden Libraries gemergt und released sind - ihre RC-Artefakte liegen bisher nur lokal:

- `xpath-helper`

Ticket: https://avides.atlassian.net/browse/LIBRARIES-1751
Epic: https://avides.atlassian.net/browse/ITGS-470